### PR TITLE
Add backend observability with Prometheus metrics, OpenTelemetry tracing, and set up Docker Compose

### DIFF
--- a/token-tracker-backend/Dockerfile
+++ b/token-tracker-backend/Dockerfile
@@ -1,0 +1,21 @@
+# python environment
+FROM python:3.13-slim
+
+# set working directory
+WORKDIR /app
+
+# install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# COPY rest of app
+COPY . .
+
+# Expose FastAPI port (documentation)
+EXPOSE 8000
+
+# command to run app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+
+

--- a/token-tracker-backend/README.md
+++ b/token-tracker-backend/README.md
@@ -1,24 +1,72 @@
-Change Directory:
+# Project setup (w/o Docker)
+
+- Change Directory:
 
 ```
 cd token-tracker-backend
 ```
 
-Create a virtual environment and activate it:
+- Create a virtual environment and activate it:
 
 ```
 python -m venv venv
 source venv/bin/activate  # On Windows use `venv\Scripts\activate`
 ```
 
-Install the dependencies:
+- Install the dependencies:
 
 ```
 pip install -r requirements.txt
 ```
 
-Run the file:
+- Run the file:
 
 ```
 uvicorn app.main:app --reload
 ```
+
+# Docker Setup (Local Development + Testing)
+
+- Start services and build dockerfile
+
+```
+docker compose up --build
+```
+
+- Stop and remove containers
+
+```
+docker compose down # to remove volumes add --volumes
+```
+
+## Grafana
+
+Visit `http://localhost:3000` and login using `admin` and `admin`
+
+- Add promtheus as data source
+  - URL = `http://prometheus:9090`
+  - Leave auth disabled
+  - Save
+- Add tempo as data source
+  - URL = `http://tempo:3200`
+  - Leave auth disabled
+  - Save
+
+### Trigger metrics (testing)
+
+Open terminal
+
+```
+curl -X POST http://localhost:8000/debug/test    # for metrics
+curl -X POST http://localhost:8000/debug/span    # for traces
+```
+
+### View Output
+
+##### View Metrics
+
+- Click Explore, select Prometheus, select `chat_token_usage_total` or `chat_request_latency_seconds_count` as metric and run query
+
+##### View Traces
+
+- Click Explore, select Tempo, select Query type as `Search`, then select `token-tracker-service` as Service Name and run query

--- a/token-tracker-backend/README.md
+++ b/token-tracker-backend/README.md
@@ -43,15 +43,6 @@ docker compose down # to remove volumes add --volumes
 
 Visit `http://localhost:3000` and login using `admin` and `admin`
 
-- Add promtheus as data source
-  - URL = `http://prometheus:9090`
-  - Leave auth disabled
-  - Save
-- Add tempo as data source
-  - URL = `http://tempo:3200`
-  - Leave auth disabled
-  - Save
-
 ### Trigger metrics (testing)
 
 Open terminal

--- a/token-tracker-backend/README.md
+++ b/token-tracker-backend/README.md
@@ -1,3 +1,9 @@
+Change Directory:
+
+```
+cd token-tracker-backend
+```
+
 Create a virtual environment and activate it:
 
 ```
@@ -5,8 +11,14 @@ python -m venv venv
 source venv/bin/activate  # On Windows use `venv\Scripts\activate`
 ```
 
-Install the dependencies: :
+Install the dependencies:
 
 ```
 pip install -r requirements.txt
+```
+
+Run the file:
+
+```
+uvicorn app.main:app --reload
 ```

--- a/token-tracker-backend/app/main.py
+++ b/token-tracker-backend/app/main.py
@@ -1,1 +1,24 @@
-# Create app, Fast API
+from fastapi import FastAPI
+from prometheus_client import make_asgi_app
+from app.observability import metrics
+from app.observability.otel import trace
+
+# Create app
+app = FastAPI(debug=False)
+
+# Create trace
+tracer = trace.get_tracer(__name__)
+
+# Add prometheus asgi middleware to route /metrics requests
+metrics_app = make_asgi_app()
+app.mount("/metrics", metrics_app)
+
+@app.get("/")
+def health_check():
+    return {"status": "ok"}
+
+@app.post("/debug/test")
+def observe_metrics():
+    metrics.track_tokens(43)
+    metrics.track_latency_seconds(0.7)
+    return {"message": "dummy metrics data fed"}

--- a/token-tracker-backend/app/main.py
+++ b/token-tracker-backend/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from prometheus_client import make_asgi_app
 from app.observability import metrics
 from app.observability.otel import trace
+import time
 
 # Create app
 app = FastAPI(debug=False)
@@ -22,3 +23,25 @@ def observe_metrics():
     metrics.track_tokens(43)
     metrics.track_latency_seconds(0.7)
     return {"message": "dummy metrics data fed"}
+
+@app.post("/debug/span")
+def observe_spans():
+    latency = 0.7
+    token_count = 43
+
+    # handles /chat logic
+    with tracer.start_as_current_span('handle /debug/span') as parent_span:
+        time.sleep(0.1)
+
+        # child span for groq api call
+        with tracer.start_as_current_span("simulate LLM call") as llm_call_span:
+            time.sleep(0.3)
+
+        # child span for detoxify call
+        with tracer.start_as_current_span("simulate toxicity check") as toxicity_span:
+            time.sleep(0.2)
+
+        # track metrics for prometheus
+        metrics.track_tokens(latency)
+        metrics.track_latency_seconds(token_count)
+    return {"message": "spans recorded"}

--- a/token-tracker-backend/app/observability/metrics.py
+++ b/token-tracker-backend/app/observability/metrics.py
@@ -1,0 +1,22 @@
+from prometheus_client import Counter, Histogram
+
+# Define which metrics you want to track that Prometheus will monitor
+
+# Counter: track cumulative token usage
+chat_token_usage_total = Counter(
+    'chat_token_usage_total', 
+    'Track total number of LLM tokens used by /chat endpoint'
+)
+
+# histogram: track cumulative token usage
+chat_request_latency_seconds = Histogram(
+    'chat_request_latency_seconds', 
+    'Track request latency in seconds for /chat endpoint'
+)
+
+# Helpers (to be called from routes to update metrics)
+def track_tokens(tokens: int = 1):
+    chat_token_usage_total.inc(tokens)
+
+def track_latency_seconds(latency: float):
+    chat_request_latency_seconds.observe(latency)

--- a/token-tracker-backend/app/observability/otel.py
+++ b/token-tracker-backend/app/observability/otel.py
@@ -1,7 +1,10 @@
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+tempo_endpoint = "http://tempo:4318/v1/traces"
 
 resource = Resource.create(attributes={
     SERVICE_NAME: "token-tracker-service"
@@ -9,8 +12,8 @@ resource = Resource.create(attributes={
 
 # create tracer engine
 tracerProvider = TracerProvider(resource=resource)
-# init span processor that will send batch of traces to an endpoint (for now use console)
-processor = BatchSpanProcessor(span_exporter=ConsoleSpanExporter())
+# init span processor that will send batch of traces to an endpoint
+processor = BatchSpanProcessor(span_exporter=OTLPSpanExporter(endpoint=tempo_endpoint))
 tracerProvider.add_span_processor(span_processor=processor)
 
 # hook everything up to enable tracing globally

--- a/token-tracker-backend/app/observability/otel.py
+++ b/token-tracker-backend/app/observability/otel.py
@@ -1,0 +1,17 @@
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+
+resource = Resource.create(attributes={
+    SERVICE_NAME: "token-tracker-service"
+})
+
+# create tracer engine
+tracerProvider = TracerProvider(resource=resource)
+# init span processor that will send batch of traces to an endpoint (for now use console)
+processor = BatchSpanProcessor(span_exporter=ConsoleSpanExporter())
+tracerProvider.add_span_processor(span_processor=processor)
+
+# hook everything up to enable tracing globally
+trace.set_tracer_provider(tracer_provider=tracerProvider)

--- a/token-tracker-backend/docker-compose.yml
+++ b/token-tracker-backend/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./docker/grafana:/etc/grafana/provisioning
+      - ./docker/grafana/provisioning:/etc/grafana/provisioning
     depends_on:
       - prometheus
       - tempo

--- a/token-tracker-backend/docker-compose.yml
+++ b/token-tracker-backend/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./docker/grafana:/etc/grafana/provisioning
+    depends_on:
+      - prometheus
+      - tempo
+
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./docker/prometheus:/etc/prometheus
+
+  tempo:
+    image: grafana/tempo:latest
+    command: ["-config.file=/etc/tempo/tempo.yaml"]
+    ports:
+      - "3200:3200" # Tempo HTTP API
+      - "4318:4318" # OTLP HTTP
+    volumes:
+      - ./docker/tempo:/etc/tempo
+
+  backened:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    depends_on:
+      - prometheus
+      - tempo

--- a/token-tracker-backend/docker/grafana/provisioning/datasources/datasources.yaml
+++ b/token-tracker-backend/docker/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,19 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    jsonData:
+      httpMethod: GET
+      tracesToLogs:
+        datasourceUid: "Prometheus"
+      tracesToMetrics:
+        datasourceUid: "Prometheus"

--- a/token-tracker-backend/docker/prometheus/prometheus.yml
+++ b/token-tracker-backend/docker/prometheus/prometheus.yml
@@ -1,0 +1,6 @@
+global:
+  scrape_interval: 15s
+scrape_configs:
+  - job_name: "token-tracker"
+    static_configs:
+      - targets: ["backened:8000"]

--- a/token-tracker-backend/docker/tempo/tempo.yaml
+++ b/token-tracker-backend/docker/tempo/tempo.yaml
@@ -1,0 +1,26 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        http:
+          endpoint: 0.0.0.0:4318
+
+ingester:
+  trace_idle_period: 10s # Default is 10s
+  max_block_bytes: 10485760 # 10 MB max size (Default is 524288000 = 500 MB)
+  max_block_duration: 5m # Default is 30m
+
+compactor:
+  compaction:
+    compacted_block_retention: 1h # Default is 1h
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /tmp/tempo/traces


### PR DESCRIPTION
This PR sets up observability for the backend. It includes Prometheus metrics collection (latency, token usage) exposed at /metrics, OpenTelemetry tracing with Tempo integration, and a /debug/span route for testing spans and metrics. Docker Compose setup is included for running Grafana, Prometheus, and Tempo locally.